### PR TITLE
Correção/alteração nos models de Planilha e TipoAmostra

### DIFF
--- a/app/models/planilha.ts
+++ b/app/models/planilha.ts
@@ -10,6 +10,9 @@ export default class Planilha extends BaseModel {
   @column()
   declare arquivo: string
 
+  @column()
+  declare laudoId: number
+
   @belongsTo(() => Laudo)
   declare laudo: BelongsTo<typeof Laudo>
 

--- a/app/models/tipo_amostra.ts
+++ b/app/models/tipo_amostra.ts
@@ -3,12 +3,21 @@ import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
 import Amostra from './amostra.js'
 
+export enum TipoAmostraNome {
+  MINERIO = 'MINERIO',
+  SEDIMENTO = 'SEDIMENTO',
+  TESTEMUNHO = 'TESTEMUNHO',
+  SOLO = 'SOLO',
+  REJEITO = 'REJEITO',
+  POLPA = 'POLPA',
+}
+
 export default class TipoAmostra extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
 
   @column()
-  declare nome: string
+  declare nome: TipoAmostraNome
 
   @hasMany(() => Amostra)
   declare amostras: HasMany<typeof Amostra>


### PR DESCRIPTION
1. Adicionei, no model de Planilha, o atributo laudoId que estava faltando para referenciar o relacionamento;
2. Alterei, no model de TipoAmostra, o tipo do atributo nome para receber os seguintes valores padrões de um enum:
    - Minério
    - Sedimento
    - Testemunho
    - Solo
    - Rejeito
    - Polpa