### PR TITLE
feat(seeders): Adiciona seeders para cadastrar dados no banco de dados

### DIFF
--- a/database/seeders/processo_seeder.ts
+++ b/database/seeders/processo_seeder.ts
@@ -1,0 +1,33 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import Processo from '#models/processo'
+
+export default class extends BaseSeeder {
+  async run() {
+    await Processo.createMany([
+      {
+        nome: 'FRX',
+        preco: 100,
+      },
+      {
+        nome: 'DRX',
+        preco: 100,
+      },
+      {
+        nome: 'Britagem',
+        preco: 10,
+      },
+      {
+        nome: 'Moinho de Anéis',
+        preco: 15,
+      },
+      {
+        nome: 'Homogeneização e Quarteamento',
+        preco: 30,
+      },
+      {
+        nome: 'Pulverização',
+        preco: 16.16,
+      },
+    ])
+  }
+}

--- a/database/seeders/tecnico_seeder.ts
+++ b/database/seeders/tecnico_seeder.ts
@@ -1,0 +1,25 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import Tecnico from '#models/tecnico'
+
+export default class extends BaseSeeder {
+  async run() {
+    await Tecnico.createMany([
+      {
+        nome: 'Jardson',
+        matricula: '20241038060006',
+      },
+      {
+        nome: 'Ian',
+        matricula: '20241038060011',
+      },
+      {
+        nome: 'Robério',
+        matricula: '20241038060010',
+      },
+      {
+        nome: 'Lucas',
+        matricula: '20241038060003',
+      },
+    ])
+  }
+}

--- a/database/seeders/tipo_amostra_seeder.ts
+++ b/database/seeders/tipo_amostra_seeder.ts
@@ -1,0 +1,28 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import TipoAmostra from '#models/tipo_amostra'
+import { TipoAmostraNome } from '#models/tipo_amostra'
+
+export default class extends BaseSeeder {
+  async run() {
+    await TipoAmostra.createMany([
+      {
+        nome: TipoAmostraNome.MINERIO,
+      },
+      {
+        nome: TipoAmostraNome.POLPA,
+      },
+      {
+        nome: TipoAmostraNome.REJEITO,
+      },
+      {
+        nome: TipoAmostraNome.SEDIMENTO,
+      },
+      {
+        nome: TipoAmostraNome.SOLO,
+      },
+      {
+        nome: TipoAmostraNome.TESTEMUNHO,
+      },
+    ])
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:17.4-alpine3.20
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ctm
+    ports:
+      - "5000:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  adminer:
+    image: adminer:latest
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
### Descrição:
Adicionei seeders para cadastrarem dados que precisam estar dentro do banco de dados na inicialização.

### Como executar as seeders:
1. Inicialize o docker: `docker compose up -d`;
2. Rode as migrations: `node ace migration:run` ou `node ace migration:fresh`;
3. Execute as seeders: `node ace db:seed`.